### PR TITLE
gulp関連ファイルの追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ vendor/bundle
 
 # Cache #
 #########
+.cache
 .sass-cache
 
 # Generated CSS #
@@ -49,3 +50,7 @@ vendor/bundle
 user/media/theme/*/media/css
 *.css
 *.map
+
+# NPM #
+#######
+node_modules

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) 2016-2017 Sho Sakakibara
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/config.json
+++ b/config.json
@@ -1,0 +1,9 @@
+{
+  "name": "案件名",
+  "theme": "THEME-NAME",
+  "host": "",
+  "user": "",
+  "password": "",
+  "root": ""
+}
+

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,173 @@
+var fs = require('fs');
+var del = require('del');
+var gulp = require('gulp');
+var gutil = require('gulp-util');
+var replace = require('gulp-replace');
+var runSequence = require('run-sequence');
+var convertEncoding = require('gulp-convert-encoding');
+var sass = require('gulp-sass');
+var sassGlob = require('gulp-sass-glob');
+var browserSync = require('browser-sync').create();
+var vinylFtp = require('vinyl-ftp');
+var config = JSON.parse(fs.readFileSync('./config.json'));
+var cacheContent = fs.readFileSync('.cache', 'utf8');
+var paths = {
+  css: 'user/theme/' + config.theme + '/media/css'
+};
+var globs = {
+  html: [
+    '**/*.html',
+    '!node_modules/**/*.html'
+  ],
+  sass: [
+    'user/theme/' + config.theme + '/media/sass/**/*.scss'
+  ],
+  js: [
+    'user/theme/' + config.theme + '/media/js/**/*.js'
+  ],
+  upload: [
+    '**/*.html',
+    '!node_modules/**/*.html',
+    'user/theme/' + config.theme + '/media/css/**/*.css',
+    'user/theme/' + config.theme + '/media/sass/**/*.scss',
+    'user/theme/' + config.theme + '/media/js/**/*.js',
+    'user/theme/' + config.theme + '/media/img/**/*.jpg',
+    'user/theme/' + config.theme + '/media/img/**/*.gif',
+    'user/theme/' + config.theme + '/media/img/**/*.png',
+    'user/media/' + config.theme + '/media/img/**/*.jpg',
+    'user/media/' + config.theme + '/media/img/**/*.gif',
+    'user/media/' + config.theme + '/media/img/**/*.png'
+  ]
+};
+
+
+gulp.task('rename:theme', function() {
+  var themeFolder = 'user/theme/THEME-NAME';
+
+  if (fs.existsSync('user/theme/' + cacheContent)) {
+    themeOrigin = 'user/theme/' + cacheContent;
+  } else {
+    themeOrigin = themeFolder;
+  }
+
+  return gulp.src(themeOrigin + '/**')
+    .pipe(gulp.dest('user/theme/' + config.theme));
+});
+
+gulp.task('rename:media', function() {
+  var mediaFolder = 'user/media/THEME-NAME';
+
+  if (fs.existsSync('user/media/' + cacheContent)) {
+    mediaOrigin = 'user/media/' + cacheContent;
+  } else {
+    mediaOrigin = mediaFolder;
+  }
+
+  return gulp.src(mediaOrigin + '/**')
+    .pipe(gulp.dest('user/media/' + config.theme));
+});
+
+gulp.task('replace:config', function() {
+  var configOrigin = 'user/theme/' + config.theme + '/config.php';
+
+  return gulp.src(configOrigin, {
+      base: './'
+    })
+    .pipe(replace(/(title\' => \')(.*?)(?=\')/,
+      '$1' + config.name))
+    .pipe(replace(/(desc\' => \')(.*?)(?=\')/,
+      '$1' + config.name + 'のテーマです。'))
+    .pipe(convertEncoding({
+      to: 'utf-8'
+    }))
+    .pipe(gulp.dest('./'));
+});
+
+gulp.task('replace:path', function() {
+  var pathOrigin = globs.html.concat(globs.sass, globs.js);
+
+  return gulp.src(pathOrigin, {
+      base: './'
+    })
+    .pipe(replace(/(user\/theme\/)(.*?)(?=\/)/g,
+      '$1' + config.theme))
+    .pipe(replace(/(user\/media\/)(.*?)(?=\/)/g,
+      '$1' + config.theme))
+    .pipe(convertEncoding({
+      to: 'utf-8'
+    }))
+    .pipe(gulp.dest('./'));
+});
+
+gulp.task('clean', function() {
+  var removeList = ['user/theme/THEME-NAME/**', 'user/media/THEME-NAME/**'],
+    oldTheme = 'user/theme/' + cacheContent;
+
+  if (fs.existsSync(oldTheme) && cacheContent != config.theme) {
+    removeList.push(oldTheme + '/**');
+  }
+
+  return del(removeList);
+});
+
+gulp.task('cache', function() {
+  return fs.writeFileSync('.cache', config.theme);
+});
+
+gulp.task('init', function(cb) {
+  runSequence(
+    ['rename:theme', 'rename:media'],
+    ['replace:config', 'replace:path'],
+    'clean',
+    'cache',
+    cb);
+});
+
+gulp.task('sass', function() {
+  return gulp.src(globs.sass)
+    .pipe(sassGlob())
+    .pipe(sass({
+      outputStyle: 'compressed'
+    }).on('error', sass.logError))
+    .pipe(gulp.dest(paths.css))
+    .pipe(browserSync.stream());
+});
+
+gulp.task('serve', ['sass'], function() {
+  browserSync.init({
+    server: {
+      baseDir: "."
+    }
+  });
+});
+
+gulp.task('deploy', ['sass'], function() {
+  var conn = vinylFtp.create({
+    host: config.host,
+    user: config.user,
+    password: config.password,
+    parallel: 8,
+    log: gutil.log
+  });
+  return gulp.src(globs.upload, {
+      base: '.',
+      buffer: false
+    })
+    .pipe(conn.newer(config.root))
+    .pipe(conn.dest(config.root))
+});
+
+gulp.task('watch', ['sass', 'serve'], function() {
+  gulp.watch(globs.sass, ['sass']);
+  gulp.watch(globs.js).on('change', browserSync.reload);
+  gulp.watch(globs.html).on('change', browserSync.reload);
+});
+
+gulp.task('watch:deploy', ['sass', 'serve', 'deploy'], function() {
+  gulp.watch(globs.sass, ['sass']);
+  gulp.watch(globs.js).on('change', browserSync.reload);
+  gulp.watch(globs.html).on('change', browserSync.reload);
+  gulp.watch(globs.upload, ['deploy']);
+});
+
+gulp.task('default', ['watch']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,7 +10,9 @@ var sassGlob = require('gulp-sass-glob');
 var browserSync = require('browser-sync').create();
 var vinylFtp = require('vinyl-ftp');
 var config = JSON.parse(fs.readFileSync('./config.json'));
-var cacheContent = fs.readFileSync('.cache', 'utf8');
+if (fs.existsSync('.cache')) {
+    var cacheContent = fs.readFileSync('.cache', 'utf8');
+}
 var paths = {
   css: 'user/theme/' + config.theme + '/media/css'
 };

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "s3-template",
+  "description": "s3-template",
+  "version": "0.0.1",
+  "homepage": "https://github.com/natrin/s3-template",
+  "author": {
+    "name": "Sho Sakakibara",
+    "email": "sakakibara@ritaworks.jp"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/natrin/s3-template.git"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "browser-sync": "^2.18.7",
+    "del": "^2.2.2",
+    "gulp": "^3.9.1",
+    "gulp-convert-encoding": "^1.0.0",
+    "gulp-replace": "^0.5.4",
+    "gulp-sass": "^3.1.0",
+    "gulp-sass-glob": "^1.0.8",
+    "gulp-util": "^3.0.8",
+    "run-sequence": "^1.2.2",
+    "vinyl-ftp": "^0.6.0"
+  }
+}


### PR DESCRIPTION
# gulp実装
以下のコマンド及び機能を実装するコミットです。

## 実装機能
### sass @importのglobパターン適用
以下のように書いていたものを
```scss
@import 'style/variable';
@import 'style/editor';
```
一行で書くことが出来ます。
```scss
@import 'style/**';
```

### BrowserSyncの実行
Browsersyncはファイル変更を監視し、自動でブラウザのリロードを行ってくれるツールです。
またサーバーを立ち上げるので
```html
<script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
```
等の「/」始まりのパスも扱うことが出来ます。

スマホから立ち上げたサーバーへアクセスするとPC上のブラウザとスクロールやリンククリックなどの動作を連動させることも出来ます。

### FTPサーバーへの自動アップロード
FTPサーバーへのアップロードが必要なファイルの更新状態を監視し、自動でアップロード出来ます。
FTP情報は後述のconfig.jsonへ記載が必要です。

### CMS案件名の変更
後述のconfig.jsonへ記載した内容をもとにテーマフォルダのリネーム、パスの修正等を一括で行います。
また、この処理は何度でも実行が可能です。

## 設定ファイル
config.jsonが設定ファイルとなっております。
中身は以下のようになっています。
実際にはコメントがついていない（というかjsonにはつけれない）のですが、便宜上説明コメントを追加しています。

```javascript
{
  // name - 案件名（日本語）を入力
  "name": "案件名",

  // theme - テーマ名（半角英数字）を入力
  "theme": "THEME-NAME",

  // host, user, password, root - FTP ホスト名, ユーザー, パスワード, ルートパス
  "host": "",
  "user": "",
  "password": "",
  "root": ""
}
```

## 実装コマンド
以下のgulpコマンドが実行可能です。

### gulp init
config.jsonの情報をもとに以下の処理を行います。
※initとしてありますが複数回実行可能

- フォルダのリネーム 
```
user/theme/THEME-NAME
user/media/THEME-NAME
```

- config.php内の案件名の書き換え
```php
  'theme_title' => '案件名',
  'theme_desc' => '案件名のテーマです。',
```

- html, sassファイル内のパスの書き換え
```html
  <link rel="stylesheet" type="text/css" href="user/theme/THEME-NAME/media/css/import.css">
```

### gulp sass
Sassをコンパイルします。

### gulp serve
Sassをコンパイルし、BrowserSyncを立ち上げます。

### gulp deploy
Sassをコンパイルし、FTPへアップロードします。

### gulp watch
Sassをコンパイルし、BrowserSyncを立ち上げ、html, scssの変更を監視します。
更新時にSassのコンパイル、ブラウザのリロード、cssのインジェクションが行なわれます。

### gulp watch:deploy
Sassをコンパイルし、BrowserSyncを立ち上げ、各ファイルへの変更を監視します。
更新時にSassのコンパイル、ブラウザのリロード、cssのインジェクション、FTPサーバーへのアップロードが行われます。

Gulpデフォルトコマンド(「gulp」のみを入力)でgulp watchのタスクを実行します。