### PR TITLE
游ゴシックのフォント記述の順番変更 

### DIFF
--- a/user/theme/THEME-NAME/media/sass/_settings.scss
+++ b/user/theme/THEME-NAME/media/sass/_settings.scss
@@ -33,7 +33,7 @@ $base-line-height: 1.5;
 $base-link-color: #0000ee;
 $link-underline: true !default;
 
-$base-font: "游ゴシック体", "Yu Gothic", YuGothic, "ヒラギノ角ゴシック ProN", "Hiragino Kaku Gothic ProN", "メイリオ", Meiryo, Osaka, "ＭＳ Ｐゴシック", "MS PGothic", sans-serif;
+$base-font: "ヒラギノ角ゴシック ProN", "Hiragino Kaku Gothic ProN", "メイリオ", Meiryo, Osaka, "ＭＳ Ｐゴシック", "MS PGothic", "游ゴシック体", "Yu Gothic", YuGothic, sans-serif;
 
 // --------------------------------------------------
 // グリッドシステム設定


### PR DESCRIPTION
最近はほとんどつかわない&お客さんからフォントが汚いなどのクレームがきたりするので順番を後ろにする。