### PR TITLE
mac_initを何度でも使えるように改良

### DIFF
--- a/mac_init
+++ b/mac_init
@@ -50,12 +50,14 @@ function move() {
     dirs=()
     while IFS= read -r -d $'\0' dir; do
       dirs+=("${dir##*/}")
-    done < <(find "$base" -mindepth "1" -maxdepth "1" -type d -print0)
+    done < <(find "$base" -mindepth "1" -maxdepth "1" -type d -print0 2>/dev/null)
 
-    if [[ "${#dirs[@]}" -eq 1 ]]; then
+    if [[ "${#dirs[@]}" -eq 0 ]]; then
+      echo -e "[!] $base フォルダ内にテーマフォルダが存在していません。" && continue
+    elif [[ "${#dirs[@]}" -eq 1 ]]; then
       # $originが定義されていない、
       # もしくは定義されている名称のフォルダが存在しない場合実行する
-      if [[ -z "$origin" ]] || [[ -n "$origin" && ! -d "$base/$origin" ]]; then
+      if [[ -z "$origin" || ! -d "$base/$origin" ]]; then
         unset origin
         if [[ -d "$base/THEME-NAME" ]]; then
           origin="THEME-NAME"
@@ -63,8 +65,8 @@ function move() {
       fi
     fi
 
-    if [[ -z "$origin" ]]; then
-      PS3="移動するフォルダを数字で指定してください:"
+    if [[ -z "$origin" || ! -d "$base/$origin" ]]; then
+      PS3="移動するフォルダを数字で指定してください: "
 
       select dir in "${dirs[@]}" "移動しない"; do
         case "$dir" in
@@ -80,9 +82,8 @@ function move() {
       done
     fi
 
-    mkdir -p "$base/$theme"
-    find "$base/$origin" -mindepth "1" -prune -exec mv '{}' "$base/$theme" \;
-    rmdir "$base/$origin"
+    [[ -d "$base/$theme" ]] || mkdir -p "$base/$theme"
+    find "$base/$origin" -mindepth "1" -prune -exec mv '{}' "$base/$theme" \; && rmdir "$base/$origin"
   done
 }
 

--- a/mac_init
+++ b/mac_init
@@ -1,19 +1,90 @@
 #!/bin/bash
 
-echo "案件名とテーマ名を設定します。"
+function main(){
+  echo "案件名とテーマ名を設定します。"
 
-BASEDIR="${0%/*}"
+  # ローカル変数として宣言
+  local basedir name origin theme targets=()
 
-echo -n "案件名を日本語で入力して[RETURN]キーを押して下さい: "
-read name
-echo -n "テーマ名を半角英数字で入力して[RETURN]キーを押して下さい: "
-read theme
+  basedir="${0%/*}" targets=("media" "theme")
 
-find $BASEDIR -name '*.php' -type f -exec sed -i "" "s/案件名/$name/g" {} \;
-find $BASEDIR \( -name "*.html" -or -name "*.css" -or -name "*.scss" \) -exec sed -i "" "s/THEME-NAME/$theme/g" {} \;
-mv $BASEDIR/user/media/* "$BASEDIR/user/media/$theme/"
-mv $BASEDIR/user/theme/* "$BASEDIR/user/theme/$theme/"
+  echo -n "案件名を日本語で入力して[RETURN]キーを押して下さい: "
+  read name
+  echo -n "テーマ名を半角英数字で入力して[RETURN]キーを押して下さい: "
+  read theme
 
-find $BASEDIR -name '*.keep' | xargs rm
+  # cdできなければexit status 1で終了
+  cd $basedir || exit 1
 
-read -p "完了しました。スクリプトを終了するには[RETURN]キーを押して下さい。"
+  replace "$name" "$theme" "${targets[@]}"
+
+  move "$theme" "${targets[@]}"
+
+  find . -name "*.keep" | xargs rm
+
+  read -p "完了しました。スクリプトを終了するには[RETURN]キーを押して下さい。"
+}
+
+function replace() {
+  # ローカル変数として宣言
+  local name theme
+
+  name=$1; shift
+  theme=$1; shift
+
+  find . -name "*.php" -type f -exec sed -i "" "s:\('theme_title' => '\).*\(',\):\1$name\2:g" '{}' \;
+  find . -name "*.php" -type f -exec sed -i "" "s:\('theme_desc' => '\).*\(のテーマです。',\):\1$name\2:g" '{}' \;
+  for target; do
+    find . \( -name "*.html" -or -name "*.css" -or -name "*.scss" \) -exec sed -i "" "s:\(user/$target/\)[^/]*\(/\):\1$theme\2:g" '{}' \;
+  done
+}
+
+function move() {
+  # ローカル変数として宣言
+  local base origin theme dirs=()
+
+  theme=$1; shift
+
+  for target; do
+    base="user/$target"
+    dirs=()
+    while IFS= read -r -d $'\0' dir; do
+      dirs+=("${dir##*/}")
+    done < <(find "$base" -mindepth "1" -maxdepth "1" -type d -print0)
+
+    if [[ "${#dirs[@]}" -eq 1 ]]; then
+      # $originが定義されていない、
+      # もしくは定義されている名称のフォルダが存在しない場合実行する
+      if [[ -z "$origin" ]] || [[ -n "$origin" && ! -d "$base/$origin" ]]; then
+        unset origin
+        if [[ -d "$base/THEME-NAME" ]]; then
+          origin="THEME-NAME"
+        fi
+      fi
+    fi
+
+    if [[ -z "$origin" ]]; then
+      PS3="移動するフォルダを数字で指定してください:"
+
+      select dir in "${dirs[@]}" "移動しない"; do
+        case "$dir" in
+          "移動しない")
+            echo "フォルダ移動をキャンセルしました。"
+            break
+            ;;
+          *)
+            origin="$dir"
+            break
+            ;;
+        esac
+      done
+    fi
+
+    mkdir -p "$base/$theme"
+    find "$base/$origin" -mindepth "1" -prune -exec mv '{}' "$base/$theme" \;
+    rmdir "$base/$origin"
+  done
+}
+
+# mainが正常に走らなければexit status 1で終了
+main "$@" || exit 1

--- a/mac_init
+++ b/mac_init
@@ -4,7 +4,7 @@ function main(){
   echo "案件名とテーマ名を設定します。"
 
   # ローカル変数として宣言
-  local basedir name origin theme targets=()
+  local basedir name theme targets=()
 
   basedir="${0%/*}" targets=("media" "theme")
 
@@ -14,7 +14,7 @@ function main(){
   read theme
 
   # cdできなければexit status 1で終了
-  cd $basedir || exit 1
+  cd "$basedir" || exit 1
 
   replace "$name" "$theme" "${targets[@]}"
 


### PR DESCRIPTION
前から繰り返し実行できないのが気になっていたのですが、shell scriptがあまりわからずそのまま放置していました。
まだこのファイルを使っている方がいらっしゃるようですし、今ではshell scriptも結構書けるようになったので繰り返し実行機能を実装してみました。

使い方は元のままでOKです。
以下の条件の場合にテキストベースのメニューを表示し移動するテーマフォルダを選択できるようにしています。

1. user/theme, user/media内のフォルダ数が1つのみ、かつ"THEME-NAME"フォルダが存在しない場合
2. フォルダが２つ以上ある場合

テーマ名とパスの変更手順は従来通りのままで、何度も繰り返し実行することができるようになっています。
もしよろしければ、使ってみてください。