### PR TITLE
pdfアイコンのクラス修正

### DIFF
--- a/user/theme/THEME-NAME/media/sass/style/_common.scss
+++ b/user/theme/THEME-NAME/media/sass/style/_common.scss
@@ -62,7 +62,7 @@ a[href^="tel:"] {
 }
 
 //CMS-PDFアイコン設定
-.pdf-icon {
+.pdf_icon {
   vertical-align: middle;
   height: 16px;
   padding: 0 5px;


### PR DESCRIPTION
誤：.pdf-icon
正：.pdf_icon