### PR TITLE
header固定の場合の印刷表示設定

### DIFF
--- a/user/theme/THEME-NAME/media/sass/core/_print.scss
+++ b/user/theme/THEME-NAME/media/sass/core/_print.scss
@@ -6,3 +6,14 @@
     display: none !important;
   }
 }
+
+header {
+  @if $header-fixed-pc {
+       position: fixed;
+//ここから
+       @media only print {
+           position: inherit;
+    }
+//ここまで
+  }
+}


### PR DESCRIPTION
header固定の場合に印刷表示が崩れてしまうため、コードを追記しました。