### PR TITLE
【修正】header固定の場合の印刷表示設定

### DIFF
--- a/user/theme/THEME-NAME/media/sass/core/_print.scss
+++ b/user/theme/THEME-NAME/media/sass/core/_print.scss
@@ -6,3 +6,8 @@
     display: none !important;
   }
 }
+header {
+       @media only print {
+           position: inherit;
+    }
+}


### PR DESCRIPTION
header固定の場合に印刷表示が崩れてしまうため、コードを追記しました。
↑こちらのコードを修正しました