### PR TITLE
印刷時の表示崩れを解消

### DIFF
--- a/user/theme/THEME-NAME/media/sass/core/_print.scss
+++ b/user/theme/THEME-NAME/media/sass/core/_print.scss
@@ -9,6 +9,10 @@
 
 header {
   @media only print {
-    position: inherit;
+    position: inherit !important;
   }
+}
+
+.l-container {
+  overflow: visible !important;
 }


### PR DESCRIPTION
.l-container に overflow: hidden; を記述すると、印刷時に右30%くらい見切れてしまうので、印刷時はvisibleになるよう変更しました。